### PR TITLE
Bugfixes

### DIFF
--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -26,7 +26,7 @@ namespace rmatch {
             we have to set those bits to 0
             we just have to do an XOR
         */
-        const boost::dynamic_bitset<> XOR = lowbits ^ topbits;
+        const boost::dynamic_bitset<> XOR = topbits - lowbits;
 
         /*
             we have the bits now 1 where the suffix is in the given bound

--- a/include/gs_count.hpp
+++ b/include/gs_count.hpp
@@ -121,9 +121,9 @@ index_type gs_count_range(
         string_type e, index_type m2,
         index_type k)
 {
-    return
-        gs_count_less(x,n,e,m2,k)-
-        gs_count_less(x,n,b,m1,k);
+    index_type l = gs_count_less(x,n,b,m1,k);
+    index_type u = gs_count_less(x,n,e,m2,k);
+    return u < l ? 0 : u - l;
 }
 
 /**

--- a/include/kmp_match.hpp
+++ b/include/kmp_match.hpp
@@ -211,7 +211,8 @@ private:
                 k = i;
                 l = 0;
             } else {
-                l = lcp[i-j];
+                // lcp[i] = lcp(p,p[i+1,m))
+                l = lcp[i-j-1];
             }
             if (i+l == k) {
                 while (l < m && k < n && p[l] == t[k]) {

--- a/include/naive_match.hpp
+++ b/include/naive_match.hpp
@@ -37,10 +37,10 @@ void naive_match_range(
     typedef typename iterator_traits<input_iterator>::difference_type diff;
     typedef typename make_unsigned<diff>::type size_type;
     /* Iterate over all suffixes and compare to patterns lexicographically */
-    for (size_type i = 0; t != te; ++t, ++i, ++r) {
+    for (size_type i = 0; t != te; ++t, ++i) {
         if (
                  lexicographical_compare(t,te,u,ue) &&
-                !lexicographical_compare(t,te,l,le)) *r = i;
+                !lexicographical_compare(t,te,l,le)) *r++ = i;
     }
 }
 


### PR DESCRIPTION
Fix the most glaring bugs in the algorithms:
- KMP-algorithm bug giving totally wrong results for some patterns
- Naive algorithm output iterator incrementation bug
- Wrong results in various algorithms when upper pattern is lexicographically smaller than lower pattern
